### PR TITLE
Add TUI input history navigation

### DIFF
--- a/packages/tui/internal/commands/command.go
+++ b/packages/tui/internal/commands/command.go
@@ -106,6 +106,8 @@ const (
 	InputPasteCommand           CommandName = "input_paste"
 	InputSubmitCommand          CommandName = "input_submit"
 	InputNewlineCommand         CommandName = "input_newline"
+	HistoryPreviousCommand      CommandName = "history_previous"
+	HistoryNextCommand          CommandName = "history_next"
 	MessagesPageUpCommand       CommandName = "messages_page_up"
 	MessagesPageDownCommand     CommandName = "messages_page_down"
 	MessagesHalfPageUpCommand   CommandName = "messages_half_page_up"
@@ -263,6 +265,16 @@ func LoadFromConfig(config *opencode.Config) CommandRegistry {
 			Name:        InputNewlineCommand,
 			Description: "insert newline",
 			Keybindings: parseBindings("shift+enter", "ctrl+j"),
+		},
+		{
+			Name:        HistoryPreviousCommand,
+			Description: "previous input",
+			Keybindings: parseBindings("up"),
+		},
+		{
+			Name:        HistoryNextCommand,
+			Description: "next input",
+			Keybindings: parseBindings("down"),
 		},
 		{
 			Name:        MessagesPageUpCommand,

--- a/packages/tui/internal/components/chat/editor.go
+++ b/packages/tui/internal/components/chat/editor.go
@@ -39,6 +39,8 @@ type EditorComponent interface {
 	Clear() (tea.Model, tea.Cmd)
 	Paste() (tea.Model, tea.Cmd)
 	Newline() (tea.Model, tea.Cmd)
+	HistoryPrevious() (tea.Model, tea.Cmd)
+	HistoryNext() (tea.Model, tea.Cmd)
 	SetValue(value string)
 	SetInterruptKeyInDebounce(inDebounce bool)
 	SetExitKeyInDebounce(inDebounce bool)
@@ -50,6 +52,8 @@ type editorComponent struct {
 	spinner                spinner.Model
 	interruptKeyInDebounce bool
 	exitKeyInDebounce      bool
+	history                []string
+	historyIndex           int
 }
 
 func (m *editorComponent) Init() tea.Cmd {
@@ -357,6 +361,9 @@ func (m *editorComponent) Submit() (tea.Model, tea.Cmd) {
 		})
 	}
 
+	m.history = append(m.history, value)
+	m.historyIndex = len(m.history)
+
 	updated, cmd := m.Clear()
 	m = updated.(*editorComponent)
 	cmds = append(cmds, cmd)
@@ -400,6 +407,34 @@ func (m *editorComponent) Paste() (tea.Model, tea.Cmd) {
 
 func (m *editorComponent) Newline() (tea.Model, tea.Cmd) {
 	m.textarea.Newline()
+	return m, nil
+}
+
+func (m *editorComponent) HistoryPrevious() (tea.Model, tea.Cmd) {
+	if len(m.history) == 0 {
+		return m, nil
+	}
+	if m.historyIndex > 0 {
+		m.historyIndex--
+	}
+	m.SetValue(m.history[m.historyIndex])
+	m.textarea.CursorEnd()
+	return m, nil
+}
+
+func (m *editorComponent) HistoryNext() (tea.Model, tea.Cmd) {
+	if len(m.history) == 0 {
+		m.SetValue("")
+		return m, nil
+	}
+	if m.historyIndex < len(m.history)-1 {
+		m.historyIndex++
+		m.SetValue(m.history[m.historyIndex])
+	} else {
+		m.historyIndex = len(m.history)
+		m.SetValue("")
+	}
+	m.textarea.CursorEnd()
 	return m, nil
 }
 
@@ -487,6 +522,8 @@ func NewEditorComponent(app *app.App) EditorComponent {
 		textarea:               ta,
 		spinner:                s,
 		interruptKeyInDebounce: false,
+		history:                []string{},
+		historyIndex:           0,
 	}
 
 	return m

--- a/packages/tui/internal/tui/tui.go
+++ b/packages/tui/internal/tui/tui.go
@@ -950,6 +950,14 @@ func (a appModel) executeCommand(command commands.Command) (tea.Model, tea.Cmd) 
 		updated, cmd := a.editor.Newline()
 		a.editor = updated.(chat.EditorComponent)
 		cmds = append(cmds, cmd)
+	case commands.HistoryPreviousCommand:
+		updated, cmd := a.editor.HistoryPrevious()
+		a.editor = updated.(chat.EditorComponent)
+		cmds = append(cmds, cmd)
+	case commands.HistoryNextCommand:
+		updated, cmd := a.editor.HistoryNext()
+		a.editor = updated.(chat.EditorComponent)
+		cmds = append(cmds, cmd)
 	case commands.MessagesFirstCommand:
 		updated, cmd := a.messages.First()
 		a.messages = updated.(chat.MessagesComponent)

--- a/packages/tui/sdk/config.go
+++ b/packages/tui/sdk/config.go
@@ -518,6 +518,10 @@ type Keybinds struct {
 	InputPaste string `json:"input_paste,required"`
 	// Submit input
 	InputSubmit string `json:"input_submit,required"`
+	// Previous input history
+	HistoryPrevious string `json:"history_previous,required"`
+	// Next input history
+	HistoryNext string `json:"history_next,required"`
 	// Leader key for keybind combinations
 	Leader string `json:"leader,required"`
 	// Copy message
@@ -580,6 +584,8 @@ type keybindsJSON struct {
 	InputNewline         apijson.Field
 	InputPaste           apijson.Field
 	InputSubmit          apijson.Field
+	HistoryPrevious      apijson.Field
+	HistoryNext          apijson.Field
 	Leader               apijson.Field
 	MessagesCopy         apijson.Field
 	MessagesFirst        apijson.Field


### PR DESCRIPTION
## Summary
- add `history_previous` and `history_next` commands with default keybinds
- record input history in the editor and allow cycling with arrow keys

## Testing
- `go test ./...` *(fails: suspect or, undefined: WithMaxVisibleItems)*

------
https://chatgpt.com/codex/tasks/task_e_68768685044c8329b3a6958109f29da4